### PR TITLE
Clarify which dialog option to choose for the guide to work

### DIFF
--- a/Guides/Legacy.lua
+++ b/Guides/Legacy.lua
@@ -5675,6 +5675,7 @@ goto 23.28,22.40
 step
 goto 23.28,22.40
 talk Gargak |q A Chief Concern/Talk to Gargak
+|tip Propose to avoid further bloodshed
 step
 goto 23.28,22.40
 talk Gargak |q A Chief Concern/Convince Gargak to End His Feud


### PR DESCRIPTION
If the user chooses the killing option, the guide will no longer apply.